### PR TITLE
Completion of waitForGreenDeployment is now optional

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -460,7 +460,8 @@ function waitForGreenDeployment {
     if [[ "${ENABLE_ROLLBACK}" != "false" ]]; then
       rollback
     fi
-    exit 1
+    echo "WARNING - Deployment took more than $TIMEOUT to complete; releasing script. Check service in AWS console."
+    exit 0
   fi
 }
 


### PR DESCRIPTION
waitForGreenDeployment now returns `exit 0` instead if `exit 1` if it exceeds $TIMEOUT, to avoid unnecessary script error.