### PR TITLE
Adding input parameter management

### DIFF
--- a/service-deploy.sh
+++ b/service-deploy.sh
@@ -5,6 +5,13 @@
 # Usage: service-deploy.sh {Tag name} {registry URL} {ECS cluster name} {AWS access key ID} {AWS access key secret}
 ##
 
+TAG=$(echo $1 | tr '/' '-')
+REGISTRY=$2
+SERVICE_NAME=$3
+CLUSTER_NAME=$4
+export AWS_ACCESS_KEY_ID=$5
+export AWS_SECRET_ACCESS_KEY=$6
+
 while [[ $# -gt 0 ]]
 do
 		key="$1"
@@ -50,12 +57,6 @@ do
 		shift # past argument or value
 done
 
-TAG=$(echo $1 | tr '/' '-')
-REGISTRY=$2
-SERVICE_NAME=$3
-CLUSTER_NAME=$4
-export AWS_ACCESS_KEY_ID=$5
-export AWS_SECRET_ACCESS_KEY=$6
 
 eval $(aws ecr get-login --region $AWS_REGION --no-include-email) #needs AWS_REGION AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY envvars
 

--- a/service-deploy.sh
+++ b/service-deploy.sh
@@ -79,7 +79,7 @@ docker push $REGISTRY:travis-$TRAVIS_BUILD_NUMBER
 
 if [ -n "$ADDITIONAL_TAG" ]; then 
 	docker tag $IMAGE_NAME:$COMMIT $REGISTRY:$ADDITIONAL_TAG
-	docker push $REGISTRY:ADDITIONAL_TAG
+	docker push $REGISTRY:$ADDITIONAL_TAG
 fi
 
 curl https://raw.githubusercontent.com/AttestationLegale/ecs-deploy/master/ecs-deploy > ecs-deploy

--- a/service-deploy.sh
+++ b/service-deploy.sh
@@ -5,6 +5,51 @@
 # Usage: service-deploy.sh {Tag name} {registry URL} {ECS cluster name} {AWS access key ID} {AWS access key secret}
 ##
 
+while [[ $# -gt 0 ]]
+do
+		key="$1"
+
+		case $key in
+				-k|--aws-access-key)
+						AWS_ACCESS_KEY_ID="$2"
+						shift # past argument
+						;;
+				-s|--aws-secret-key)
+						AWS_SECRET_ACCESS_KEY="$2"
+						shift # past argument
+						;;
+				-r|--region)
+						AWS_REGION="$2"
+						shift # past argument
+						;;
+				-c|--cluster)
+						CLUSTER_NAME="$2"
+						shift # past argument
+						;;
+				-n|--service-name)
+						SERVICE_NAME="$2"
+						shift # past argument
+						;;
+				-R|--registry)
+						REGISTRY="$2"
+						shift
+						;;
+				-t|--tag)
+						TAG="$2"
+						shift
+						;;
+				-T|--additional-tag)
+						ADDITIONAL_TAG="$2"
+						shift
+						;;
+				*)
+						# usage #TODO: usage to do
+						# exit 2
+				;;
+		esac
+		shift # past argument or value
+done
+
 TAG=$(echo $1 | tr '/' '-')
 REGISTRY=$2
 SERVICE_NAME=$3
@@ -30,6 +75,12 @@ else
 	docker push $REGISTRY:RC
 fi
 docker push $REGISTRY:travis-$TRAVIS_BUILD_NUMBER
+
+if [ -n "$ADDITIONAL_TAG" ]; then 
+	docker tag $IMAGE_NAME:$COMMIT $REGISTRY:$ADDITIONAL_TAG
+	docker push $REGISTRY:ADDITIONAL_TAG
+fi
+
 curl https://raw.githubusercontent.com/AttestationLegale/ecs-deploy/master/ecs-deploy > ecs-deploy
 chmod +x ecs-deploy
 


### PR DESCRIPTION
This PR contains the first steps of using input parameters properly, using actual parameters instead of simple input. Future update will be needed, along with modifications in .travis.yml files.

New parameter `-T` is included, to add an additional tag to the Docker image. This can be used to add "KEEP" tag, which won't be deleted from ECR due to new lifecycle policy.